### PR TITLE
Added ellipsis to undo bar

### DIFF
--- a/library/res/layout/undobar.xml
+++ b/library/res/layout/undobar.xml
@@ -5,7 +5,9 @@
 
     <TextView
         android:id="@+id/undobar_message"
-        style="@style/UndoBarMessage" />
+        style="@style/UndoBarMessage"
+        android:maxLines="1"
+        android:ellipsize="end" />
 
     <View
         android:id="@+id/undobar_divider"


### PR DESCRIPTION
Instead of multi-line undo bar messages, this will add an ellipsis to the end of the message to prevent it from overflowing to a new line.

This is the same way Gmail and Google Chrome UndoBars display their message.

At the very least, there should be an option to add an ellipsis when setting the UndoBarController.
