### PR TITLE
show(boolean) toggles both in and out animation simultaneously for consistency

### DIFF
--- a/library/src/com/cocosw/undobar/UndoBarController.java
+++ b/library/src/com/cocosw/undobar/UndoBarController.java
@@ -71,11 +71,16 @@ public class UndoBarController extends LinearLayout {
             if (mUndoListener instanceof AdvancedUndoListener) {
                 ((AdvancedUndoListener) mUndoListener).onHide(mUndoToken);
             }
-            hideUndoBar(false);
+            if (mImmediate) {
+                hideUndoBar(true);
+            } else {
+                hideUndoBar(false);
+            }
         }
     };
     private UndoListener mUndoListener;
     // State objects
+    private boolean mImmediate;
     private Parcelable mUndoToken;
     private CharSequence mUndoMessage;
     //Only for KitKat translucent mode
@@ -97,7 +102,11 @@ public class UndoBarController extends LinearLayout {
                         if (mUndoListener != null) {
                             mUndoListener.onUndo(mUndoToken);
                         }
-                        hideUndoBar(false);
+                        if (mImmediate) {
+                            hideUndoBar(true);
+                        } else {
+                            hideUndoBar(false);
+                        }
                     }
                 }
         );
@@ -379,6 +388,7 @@ public class UndoBarController extends LinearLayout {
     @Override
     public Parcelable onSaveInstanceState() {
         final Bundle outState = new Bundle();
+        outState.putBoolean("immediate", mImmediate);
         outState.putCharSequence("undo_message", mUndoMessage);
         outState.putParcelable("undo_token", mUndoToken);
         outState.putParcelable("undo_style", style);
@@ -391,6 +401,7 @@ public class UndoBarController extends LinearLayout {
     public void onRestoreInstanceState(final Parcelable state) {
         if (state instanceof Bundle) {
             final Bundle bundle = (Bundle) state;
+            mImmediate = bundle.getBoolean("immediate");
             mUndoMessage = bundle.getCharSequence("undo_message");
             mUndoToken = bundle.getParcelable("undo_token");
             style = bundle.getParcelable("undo_style");
@@ -404,6 +415,7 @@ public class UndoBarController extends LinearLayout {
     @SuppressWarnings("ConstantConditions")
     private void showUndoBar(final boolean immediate,
                              final CharSequence message, final Parcelable undoToken) {
+        mImmediate = immediate;
         mUndoToken = undoToken;
         mUndoMessage = message;
         mMessageView.setText(mUndoMessage);


### PR DESCRIPTION
Calling `show(false)` results in an Undo bar that does not animate in, but does animate out.  I thought it would be better for `show(boolean)` to toggle both in and out animations simultaneously for ease of use and to encourage consistency in UX.
